### PR TITLE
EDATEC Full and Light Hotspot Updates: Change LoRaWAN frequencies to EU868 and US915

### DIFF
--- a/applications/edatec-light.md
+++ b/applications/edatec-light.md
@@ -32,13 +32,13 @@ Thanks to more than 4 years’ experience in developing IoT market and intensive
 
 **Expected Release Date:** Q2 2022
 
-EDA-IoT Light Hotspot is a new Light Hotspot for PoC and Data Transfer. It is based on ARM Cortex A53 Quad Core 1GHz processors and Semtech SX1303 LoRa concentrator chip-set. The LoRaWAN frequencies we are planning to support are EU433, CN470, IN865, EU868, AU915, US915, KR920, AS920, and AS923. The product will be certified by FCC & CE and other regulation in specific countries.
+EDA-IoT Light Hotspot is a new Light Hotspot for PoC and Data Transfer. It is based on ARM Cortex A53 Quad Core 1GHz processors and Semtech SX1303 LoRa concentrator chip-set. The LoRaWAN frequencies we are planning to support are EU868 and US915. The product will be certified by FCC & CE and other regulation in specific countries.
 
 It is a highly reliable, easy to use, indoor light hotspot for the Helium network.
 
 **Features**
 
-* Concentrator based on the Semtech SX1303, Support EU433, CN470, IN865, EU868, AU915, US915, KR920, AS920, and AS923 LoRaWAN frequencies
+* Concentrator based on the Semtech SX1303, Support EU868 and US915 LoRaWAN frequencies
 * ARM Cortex A53 Quad Core 1GHz 64bit CPU
 * 512MB DDR
 * 8GB SD Card Storage
@@ -142,6 +142,4 @@ paypal/TT
 
 * Eurpose
 * US
-* ASEAN
-* China
 

--- a/applications/edatec.md
+++ b/applications/edatec.md
@@ -32,13 +32,13 @@ Thanks to more than 4 years’ experience in developing IoT market and intensive
 
 **Expected Release Date:** Nov 2021
 
-EDA-IoT Hotspot is a new Full Hotspot for PoC and Data Transfer. It is based on ARM Cortex A72 Quad Core 1.5GHz processors and Semtech SX1302/1303 LoRa concentrator chip-set. The LoRaWAN frequencies we are planning to support are CN470, EU868 and US915. The product will be certified by FCC & CE.
+EDA-IoT Hotspot is a new Full Hotspot for PoC and Data Transfer. It is based on ARM Cortex A72 Quad Core 1.5GHz processors and Semtech SX1302/1303 LoRa concentrator chip-set. The LoRaWAN frequencies we are planning to support are EU868 and US915. The product will be certified by FCC & CE.
 
 It is a highly reliable, easy to use, indoor full hotspot for the Helium network.
 
 **Features**
 
-* Concentrator based on the Semtech SX1302/1303, Support CN470, EU868 and US915 LoRaWAN frequencies
+* Concentrator based on the Semtech SX1302/1303, Support EU868 and US915 LoRaWAN frequencies
 * Raspberry Pi 4B Inside
   * ARM Cortex A72 Quad Core 1.5GHz 64bit CPU
   * 2GB DDR
@@ -145,7 +145,6 @@ paypal/TT
 
 ## Which countries do you plan to ship to and get regulatory certifications for?
 
-* China
 * Eurpose
 * US
 


### PR DESCRIPTION
We want to change the LoRaWAN frequencies of EDATEC Indoor Hotspot and Light Hotspot back to 'EU868 and US915':

Rendered view:
- EDATEC Indoor Full Hotspot: https://github.com/edatec/hotspot-manufacturers/blob/edatec-updates-2021-12-26/applications/edatec.md
- EDATEC Light Hotspot: https://github.com/edatec/hotspot-manufacturers/blob/edatec-updates-2021-12-26/applications/edatec-light.md
