### PR TITLE
Updates to bectechnologies.md

### DIFF
--- a/bectechnologies.md
+++ b/bectechnologies.md
@@ -48,7 +48,6 @@ established process. For details about BEC’s Warranty & RMA policy please visi
 <B>Platform details:</B>
 * Qualcomm IPQ807X 2 GHz quad-core CPU
 * 256MB Parallel NAND Flash
-* 32GB eMMC FLASH
 * 2GB DDR4 RAM
 * 4G LTE/5G CBRS connectivity (Optional)
 * 2.5 Gigabits Ethernet x 2


### PR DESCRIPTION
32GB eMMC FLASH has been removed hardware information as it is no longer needed as a Light Hotspot